### PR TITLE
[packaging] Fix audiosystem-passthrough build requirement. Contributes to JB#57351

### DIFF
--- a/rpm/pulseaudio-modules-droid-hidl.spec
+++ b/rpm/pulseaudio-modules-droid-hidl.spec
@@ -16,11 +16,11 @@ Requires:   audiosystem-passthrough >= 1.0.0
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  libtool-ltdl-devel
+BuildRequires:  audiosystem-passthrough
 BuildRequires:  pkgconfig(pulsecore) >= %{pulsemajorminor}
 BuildRequires:  pkgconfig(libdroid-util) >= %{pulsemajorminor}.41
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(android-headers)
-BuildRequires:  pkgconfig(audiosystem-passthrough)
 
 %description
 PulseAudio Droid HIDL module.


### PR DESCRIPTION
The change is to avoid this error on a fresh Platform SDK target
install:

'pkgconfig(audiosystem-passthrough)' not found in package names.
Trying capabilities.
No provider of 'pkgconfig(audiosystem-passthrough)' found.